### PR TITLE
Misc bug fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ IMPORTANT INFORMATION
  * In order for translations to work you **MUST** have the Google Translate API enabled in the
    [Google Developer Console] (https://console.developers.google.com/).
 
- * YOU **MUST** HAVE BILLIING ENABLED IN ORDER FOR THE TRANSLATE API TO WORK.
+ * YOU **MUST** HAVE BILLING ENABLED IN ORDER FOR THE TRANSLATE API TO WORK.
    This means you must add a credit card to your Google Developer Console account and enable
    for the google translate API.
 
@@ -81,10 +81,11 @@ Apply the plugin after the 'com.android.application' or 'com.android.library' pl
 Add the following section to your build.gradle file
 
     androlate {
-        appName 'API Project'
-        apiKey '********************************'
-        defaultLanguage 'en'
+        appName = 'API Project'
+        apiKey = '********************************'
+        defaultLanguage = 'en'
         targetLanguages = ['es']
+        backup = true
     }
 
 Where:
@@ -103,6 +104,9 @@ Where:
     targetLanguages
         A list of languages you are targeting.  Keep in mind androlate will submit each string to
         [Google Translate] (https://translate.google.com/) so complete translations may take a while and result in fees.
+
+    backup
+        True if string files should be backed up before modification.
 
 
 Run the androlate target to translate the string resources

--- a/examples/HelloWorld/app/build.gradle
+++ b/examples/HelloWorld/app/build.gradle
@@ -38,9 +38,10 @@ dependencies {
 
 
 androlate {
-    appName 'API Project'
-    apiKey GOOGLE_TRANSLATE_API_KEY
-    defaultLanguage 'en'
+    appName = 'API Project'
+    apiKey = GOOGLE_TRANSLATE_API_KEY
+    defaultLanguage ='en'
     targetLanguages = ['es', 'ja', 'zh-CN']
+    backup = true
 }
 

--- a/examples/HelloWorld/app/src/main/res/values/strings.xml
+++ b/examples/HelloWorld/app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
   </string-array>
   <string name="html">Welcome to <b>Android</b>!</string>
   <string name="cdata"><![CDATA[There we have some text]]></string>
+  <string name="not_translated" translatable="false">Not translated</string>
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.2
+VERSION_NAME=0.3
 GROUP=com.github.ayvazj.gradle.plugins.androlate
 
 POM_DESCRIPTION=Translate your string resources using Google Translate.

--- a/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateBaseElement.groovy
+++ b/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateBaseElement.groovy
@@ -1,7 +1,6 @@
 package com.github.ayvazj.gradle.plugins.androlate
 
 import com.google.api.services.translate.model.TranslationsResource
-import org.w3c.dom.DocumentFragment
 import org.w3c.dom.Element
 
 
@@ -19,10 +18,9 @@ abstract class AndrolateBaseElement {
 
     def public String md5() {
         if (this.node && !this.md5txt) {
-            this.md5txt = AndrolateUtils.md5sum("${this.node.getTextContent()}")
-            return this.md5txt
+            this.md5txt = AndrolateUtils.md5sum(this.node.getTextContent())
         }
-        return null;
+        return this.md5txt
     }
 
     /**
@@ -30,8 +28,7 @@ abstract class AndrolateBaseElement {
      */
     def public void updateMd5() {
         if (this.node) {
-            md5()
-            this.node.setAttributeNS(Androlate.NAMESPACE.uri, "${Androlate.NAMESPACE.prefix}:md5", this.md5txt)
+            this.node.setAttributeNS(Androlate.NAMESPACE.uri, "${Androlate.NAMESPACE.prefix}:md5", md5())
             this.node.setAttribute('name', this.node.getAttribute('name'))
         }
     }
@@ -43,10 +40,10 @@ abstract class AndrolateBaseElement {
 
     def public boolean isDirty() {
         if (this.node) {
-            def md5attr = this.node.getAttributeNodeNS(Androlate.NAMESPACE.uri, 'md5')
-            return (!md5().equals(md5attr))
+            def md5attr = this.node.getAttributeNS(Androlate.NAMESPACE.uri, 'md5')
+            return md5() != md5attr
         }
-        return true;
+        return true
     }
 
     def public String[] text() {

--- a/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateBaseElement.groovy
+++ b/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateBaseElement.groovy
@@ -36,6 +36,11 @@ abstract class AndrolateBaseElement {
         }
     }
 
+    def public boolean isTranslatable() {
+        // If translatable is false then it isn't - otherwise it is
+        return this.node.getAttribute('translatable') != "false"
+    }
+
     def public boolean isDirty() {
         if (this.node) {
             def md5attr = this.node.getAttributeNodeNS(Androlate.NAMESPACE.uri, 'md5')

--- a/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolatePluginExtension.groovy
+++ b/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolatePluginExtension.groovy
@@ -7,6 +7,7 @@ class AndrolatePluginExtension {
     def targetLanguages
     def String apiKey
     def String appName
+    def boolean backup
     private final Project project
 
     public AndrolatePluginExtension(Project project) {
@@ -14,6 +15,7 @@ class AndrolatePluginExtension {
         this.defaultLanguage = 'en'
         this.targetLanguages = []
         this.apiKey = ''
+        this.backup = true
         this.appName = null
     }
 }

--- a/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateStringArrayElement.groovy
+++ b/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateStringArrayElement.groovy
@@ -20,9 +20,8 @@ class AndrolateStringArrayElement extends AndrolateBaseElement {
                 }
             }
             this.md5txt = AndrolateUtils.md5sum(item_concat)
-            return this.md5txt
         }
-        return null;
+        return this.md5txt
     }
 
     @Override

--- a/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateTranslateTask.groovy
+++ b/src/main/groovy/com/github/ayvazj/gradle/plugins/androlate/AndrolateTranslateTask.groovy
@@ -141,7 +141,7 @@ class AndrolateTranslateTask extends DefaultTask {
                     if ("string".equals(elem.getTagName()) || "string-array".equals(elem.getTagName())) {
 
                         AndrolateBaseElement abelem = AndrolateBaseElement.newInstance(child)
-                        if (abelem.isDirty()) {
+                        if (abelem.isDirty() && abelem.isTranslatable()) {
                             abelem.updateMd5()
                             stringsdirty.add(abelem)
                         }
@@ -157,16 +157,19 @@ class AndrolateTranslateTask extends DefaultTask {
         // Add the md5 sum to the sources to avoid resending unchanged strings
         srcxml.setAttribute("xmlns:${Androlate.NAMESPACE.prefix}", Androlate.NAMESPACE.getUri().toString())
 
-        // save the modified source file
-        def backfn = AndrolateUtils.findBackupFilename(file)
-        if (!backfn) {
-            throw new GradleScriptException("Unable to create backup file")
+        if (androlate.backup) {
+            // save the modified source file
+            def backfn = AndrolateUtils.findBackupFilename(file)
+            if (!backfn) {
+                throw new GradleScriptException("Unable to create backup file")
+            }
+
+            File backFile = new File(backfn)
+            logger.log(LogLevel.INFO, "Renaming ${file.getName()} to ${backFile.getName()}")
+
+            file.renameTo(backfn)
         }
 
-        File backFile = new File(backfn)
-        logger.log(LogLevel.INFO, "Renaming ${file.getName()} to ${backFile.getName()}")
-
-        file.renameTo(backfn)
         def outwriter = new FileWriter(file.getPath())
         def fos = new FileOutputStream(file.getPath());
         def osw = new OutputStreamWriter(fos,"UTF-8");


### PR DESCRIPTION
* Skip strings marked as not translatable (i.e. `translatable="false"`). See [here](https://developer.android.com/studio/write/translations-editor.html#untranslatable).
* Add an option to avoid creating backup files - I'd argue backup files are largely unnecessary in a version controlled environment.
* Fix `isDirty` check - it was previously comparing md5 string against the attribute node rather than the attribute value, and hence always considering all strings to be dirty.
* Add `--force` flag to force translation regardless of dirty status.